### PR TITLE
fix: sitemap 생성 설정 수정

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -12,8 +12,7 @@ type Href = Parameters<typeof getPathname>[0]['href'];
 
 function getEntries(href: Href) {
   return {
-    url: getUrl(href),
-    lastModified: new Date(),
+    url: getUrl(href) + 'en',
     alternates: {
       languages: Object.fromEntries(
         routing.locales.map((cur) => [cur, getUrl(href, cur)])


### PR DESCRIPTION
### 개요

sitemap.xml 을 공식 문서를 따르도록 수정합니다.

### 상세

- [sitemaps.org](https://www.sitemaps.org/protocol.html)
  - lastmod
    - 링크 된 페이지가 사이트 맵이 생성 된 시점이 아니라 마지막으로 수정 된 날짜로 설정해야한다고 명시되어있다. 하지만 현재 설정은 빌드 시점으로 날짜가 업데이트 된다. 빌드를 했지만 해당 페이지가 수정되지 않을 경우가 있기 때문에 xml 파일을 직접 관리하는 것이 아니라 자동으로 생성되며 현재 날짜가 들어가는 것은 적절하지 않다는 판단하에 옵션인 해당 태그를 제거
- [google](https://developers.google.com/search/docs/specialty/international/localized-versions?hl=ko#sitemap)
  - loc
    - loc 또한 locale 이 prefix 되어있어야 한다. loc 에서 prefix 되어있지 않다면 봇이 중복된 페이지로 판별할 가능성이 있기 때문.
    - 현재 prefix 없이 떨어지는 페이지는 브라우저 언어 설정에 따라 떨어지도록 되어있으나, 봇은 언어 설정 없이 요청하므로 default language 인 en 을 prefix 하도록 설정
    - 터미널에서 `curl -A "Googlebot" http://localhost:3000` 를 입력하여 en 이 떨어지는 것을 확인

### 관련 이슈

- Closes #18 